### PR TITLE
Fixed Abnormal Termination of Socket connection During VectorX Events

### DIFF
--- a/das/avail/avail.go
+++ b/das/avail/avail.go
@@ -232,7 +232,7 @@ func submitData(a *AvailDA, message []byte) (gsrpc_types.Hash, gsrpc_types.UComp
 	// Send the extrinsic
 	sub, err := a.api.RPC.Author.SubmitAndWatchExtrinsic(ext)
 	if err != nil {
-		log.Warn("⚠️ cannot submit extrinsic", "error", err)
+		log.Warn("⚠️ cannot submit extrinsic", "error", err.Error())
 		return gsrpc_types.Hash{}, gsrpc_types.UCompact{}, err
 	}
 

--- a/das/avail/vectorx/vectorx.go
+++ b/das/avail/vectorx/vectorx.go
@@ -88,6 +88,7 @@ func (v *VectorX) SubscribeForHeaderUpdate(finalizedBlockNumber int, t time.Dura
 			log.Warn("Unexpected socket Closure:", err)
 			continue
 		}
+		break
 	}
 
 	return err

--- a/das/avail/vectorx/vectorx.go
+++ b/das/avail/vectorx/vectorx.go
@@ -84,7 +84,7 @@ func (v *VectorX) SubscribeForHeaderUpdate(finalizedBlockNumber int, t time.Dura
 	for i := 0; i < retryTimes; i++ {
 		log.Warn("Iteration", "Counter", strconv.Itoa(i+1), "Limit", retryTimes)
 		err = v.fetchHeaderUpdateEvent(ctx, finalizedBlockNumber)
-		if websocket.IsUnexpectedCloseError(err, websocket.CloseAbnormalClosure) {
+		if websocket.IsCloseError(err, websocket.CloseAbnormalClosure) {
 			log.Warn("Unexpected socket Closure:", err)
 			continue
 		}

--- a/das/avail/vectorx/vectorx.go
+++ b/das/avail/vectorx/vectorx.go
@@ -43,7 +43,7 @@ type VectorX struct {
 	Query  ethereum.FilterQuery
 }
 
-func (v *VectorX) subscribeForHeaderUpdate(ctx context.Context, finalizedBlockNumber int) error {
+func (v *VectorX) fetchHeaderUpdateEvent(ctx context.Context, finalizedBlockNumber int) error {
 	// Subscribe to the event stream
 	logs := make(chan types.Log)
 	sub, err := v.Client.SubscribeFilterLogs(ctx, v.Query, logs)
@@ -83,7 +83,7 @@ func (v *VectorX) SubscribeForHeaderUpdate(finalizedBlockNumber int, t time.Dura
 	var err error
 	for i := 0; i < retryTimes; i++ {
 		log.Warn("Iteration", "Counter", strconv.Itoa(i+1), "Limit", retryTimes)
-		err = v.subscribeForHeaderUpdate(ctx, finalizedBlockNumber)
+		err = v.fetchHeaderUpdateEvent(ctx, finalizedBlockNumber)
 		if websocket.IsUnexpectedCloseError(err, websocket.CloseAbnormalClosure) {
 			log.Warn("Unexpected socket Closure:", err)
 			continue


### PR DESCRIPTION
### Issue
Currently, in order to listen for finalised block event Avail Nitro Node subscribes to set of events on the Parent Chain using web sockets. However, on failure or termination of the web sockets leads to reposting of transactions on Avail and resubscribing to a new block head. This adds cost in resubmission of transaction data which was already posted earlier and also adds delays as the new block added would wait for new finalisation event to be emitted on the Parent Chain.

### Proposal
Whenever the subscription event gets an error check if it's a type of Abnormal Termination, retry to establish the connection (with an upper bound of number of retries). However, the base case of VectorX timeout and other valid errors are honoured and kept as it is. 